### PR TITLE
Properly handle invalid geometries.

### DIFF
--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -150,13 +150,15 @@ public:
                                        parent_admin_levels.end()) !=
                     parent_admin_levels.end();
 
+               const std::string linestring = m_factory.create_linestring(way);
+
                 m_out << way.id() << "\t"
                       // parent_admin_levels is already escaped.
                       << min_parent_admin_level << "\t"
                       << ((dividing_line) ? ("true") : ("false")) << "\t"
                       << ((disputed) ? ("true") : ("false")) << "\t"
                       << ((maritime) ? ("true") : ("false")) << "\t"
-                      << m_factory.create_linestring(way) << "\n";
+                      << linestring << "\n";
             } catch (osmium::geometry_error &e) {
                 std::cerr << "Geometry error on way " << way.id() << ": "
                           << e.what() << "\n";

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -150,7 +150,8 @@ public:
                                        parent_admin_levels.end()) !=
                     parent_admin_levels.end();
 
-               const std::string linestring = m_factory.create_linestring(way);
+                // Convert here to ensure errors don't result in partial output lines.
+                const std::string linestring = m_factory.create_linestring(way);
 
                 m_out << way.id() << "\t"
                       // parent_admin_levels is already escaped.


### PR DESCRIPTION
This fixes a bug caused by invalid geometries. When an invalid geometry is encountered, the code currently leaves a partially finished output line and outputs the next Way onto the same line, causing any import to fail (or drop a valid geometry because of an invalid line).

This fixes the bug by allowing errors to be caught before any output for a Way is processed.