### PR TITLE
Set maritime = true for boundary_type=maritime

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The admin_level is the lowest `admin_level` value of the parent relations. The w
 The presence of `disputed=yes`, `dispute=yes`, or `border_status=dispute` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
 
 ### maritime
-`maritime=yes` or `natural=coastline` indicates a maritime border for the purposes of rendering. Relations are not considered, nor intersection with water areas.
+`maritime=yes`, `natural=coastline` or `boundary_type=maritime` indicates a maritime border for the purposes of rendering. Relations are not considered, nor intersection with water areas.
 
 ## Options
 

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -123,6 +123,7 @@ public:
 
         maritime = maritime || way.tags().has_tag("maritime", "yes");
         maritime = maritime || way.tags().has_tag("natural", "coastline");
+        maritime = maritime || way.tags().has_tag("boundary_type", "maritime");
 
         // Tags on the parent relations
         for (const auto &rel_offset : m_way_rels[way.id()]) {


### PR DESCRIPTION
`boundary_type=maritime` does not seem to be documented anywhere, but it used 196 times, including most of the west coast of the USA.
