### PR TITLE
Also support disputed_by as disputed marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ relation members.
 The admin_level is the lowest `admin_level` value of the parent relations. The way tags are not considered.
 
 ### disputed
-The presence of `disputed=yes`, `dispute=yes`, or `border_status=dispute` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
+The presence of `disputed=yes`, `dispute=yes`, `border_status=dispute` or `disputed_by=*` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
 
 ### maritime
 `maritime=yes` or `natural=coastline` indicates a maritime border for the purposes of rendering. Relations are not considered, nor intersection with water areas.

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -120,6 +120,7 @@ public:
         disputed = disputed || way.tags().has_tag("disputed", "yes");
         disputed = disputed || way.tags().has_tag("dispute", "yes");
         disputed = disputed || way.tags().has_tag("border_status", "dispute");
+        disputed = disputed || way.tags().has_key("disputed_by");
 
         maritime = maritime || way.tags().has_tag("maritime", "yes");
         maritime = maritime || way.tags().has_tag("natural", "coastline");


### PR DESCRIPTION
Add `disputed_by` to detect more disputed boundaries.

Like at https://www.openstreetmap.org/way/526798853

Done this on the path to #13.