### PR TITLE
[WIP] Support of disputed_by and claimed_by

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ relation members.
 The admin_level is the lowest `admin_level` value of the parent relations. The way tags are not considered.
 
 ### disputed
-The presence of `disputed=yes`, `dispute=yes`, or `border_status=dispute` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
+The presence of `disputed=yes`, `dispute=yes`, `border_status=dispute` or `disputed_by=*` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
 
 ### maritime
 `maritime=yes` or `natural=coastline` indicates a maritime border for the purposes of rendering. Relations are not considered, nor intersection with water areas.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ The admin_level is the lowest `admin_level` value of the parent relations. The w
 The border is in the default netral point of view.
 
 ### disputed
-The presence of `disputed=yes`, `dispute=yes`, `border_status=dispute` or `disputed_by=*` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
+The presence of `disputed=yes`, `dispute=yes`, `border_status=dispute` or `disputed_by=*` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference.
+Also mark as disputed if part of a claimend relation.
 
 ### disputed_by
 Array of country codes not recognizing this boundary from the ways `disputed_by`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ CREATE TABLE osmborder_lines (
   osm_id bigint,
   admin_level int,
   dividing_line bool,
+  neutral bool,
   disputed bool,
   disputed_by varchar[],
   claimed_by varchar[],
@@ -81,6 +82,10 @@ relation members.
 ### admin_level
 
 The admin_level is the lowest `admin_level` value of the parent relations. The way tags are not considered.
+
+### neutral
+
+The border is in the default netral point of view.
 
 ### disputed
 The presence of `disputed=yes`, `dispute=yes`, `border_status=dispute` or `disputed_by=*` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ CREATE TABLE osmborder_lines (
   admin_level int,
   dividing_line bool,
   disputed bool,
+  disputed_by varchar[],
+  claimed_by varchar[],
   maritime bool,
   way Geometry(LineString, 3857));
 \copy osmborder_lines FROM osmborder_lines.csv
@@ -82,6 +84,12 @@ The admin_level is the lowest `admin_level` value of the parent relations. The w
 
 ### disputed
 The presence of `disputed=yes`, `dispute=yes`, `border_status=dispute` or `disputed_by=*` on the ways is used to indicate part of a border is disputed. All the tags function the same, but `disputed=yes` is my preference. Relation tags are not considered.
+
+### disputed_by
+Array of country codes not recognizing this boundary from the ways `disputed_by`.
+
+### claimed_by
+Array of country codes claiming this boundary from the relations `claimed_by`.
 
 ### maritime
 `maritime=yes` or `natural=coastline` indicates a maritime border for the purposes of rendering. Relations are not considered, nor intersection with water areas.

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -150,6 +150,7 @@ public:
     void way(const osmium::Way &way)
     {
         std::vector<int> parent_admin_levels;
+        bool neutral = false;
         bool disputed = false;
         std::vector<std::string> disputed_by;
         std::vector<std::string> claimed_by;
@@ -174,6 +175,10 @@ public:
             const osmium::TagList &tags =
                 m_relations_buffer.get<const osmium::Relation>(rel_offset)
                     .tags();
+
+            // The way is atleast in one relation of non disputed boundary
+            neutral = neutral || tags.has_tag("boundary", "administrative");
+
             const char *admin_level = tags.get_value_by_key("admin_level", "");
             /* can't use admin_levels[] because [] is non-const, but there must be a better way? */
             auto admin_it = admin_levels.find(admin_level);
@@ -220,6 +225,7 @@ public:
                       // parent_admin_levels is already escaped.
                       << min_parent_admin_level << "\t"
                       << ((dividing_line) ? ("true") : ("false")) << "\t"
+                      << ((neutral) ? ("true") : ("false")) << "\t"
                       << ((disputed) ? ("true") : ("false")) << "\t"
                       << serialize_array(disputed_by.begin(), disputed_by.end()) << "\t"
                       << serialize_array(claimed_by.begin(), claimed_by.end()) << "\t"

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -179,6 +179,9 @@ public:
             // The way is atleast in one relation of non disputed boundary
             neutral = neutral || tags.has_tag("boundary", "administrative");
 
+            // Also mark the way as disputed if is in claimed relation
+            disputed = disputed || tags.has_tag("boundary", "claim");
+
             const char *admin_level = tags.get_value_by_key("admin_level", "");
             /* can't use admin_levels[] because [] is non-const, but there must be a better way? */
             auto admin_it = admin_levels.find(admin_level);

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -120,6 +120,7 @@ public:
         disputed = disputed || way.tags().has_tag("disputed", "yes");
         disputed = disputed || way.tags().has_tag("dispute", "yes");
         disputed = disputed || way.tags().has_tag("border_status", "dispute");
+        disputed = disputed || way.tags().has_key("disputed_by");
 
         maritime = maritime || way.tags().has_tag("maritime", "yes");
         maritime = maritime || way.tags().has_tag("natural", "coastline");

--- a/src/adminhandler.hpp
+++ b/src/adminhandler.hpp
@@ -23,35 +23,42 @@
 #include <osmium/geom/mercator_projection.hpp>
 #include "util.hpp"
 
+template <typename T>
+void remove_duplicates(std::vector<T>& vec)
+{
+    std::sort(vec.begin(), vec.end());
+    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
+}
+
 void split(std::vector<std::string> & v, std::string s)
 {
     std::istringstream iss(s);
     std::string token;
     while (std::getline(iss, token, ';')) {
-        v.push_back(trim(token));
+        std::string trim_token = token;
+        // Remove quote char
+        trim_token.erase(std::remove(trim_token.begin(), trim_token.end(), '\''), trim_token.end());
+        trim_token = trim(token);
+
+        if (!trim_token.empty()) {
+            v.push_back(trim_token);
+        }
     }
 }
 
 template<typename T>
 std::string serialize_array(T begin, T end, const std::string & separator = ",")
 {
-
     std::ostringstream ss;
     ss << "{";
 
     if(begin != end) {
         std::string part = *begin++;
-        // Remove quote char
-        part.erase(std::remove(part.begin(), part.end(), '\''), part.end());
-
         ss << part;
     }
 
     while(begin != end) {
         std::string part = *begin++;
-        // Remove quote char
-        part.erase(std::remove(part.begin(), part.end(), '\''), part.end());
-
         ss << separator << part;
     }
 
@@ -193,9 +200,7 @@ public:
         }
 
         if (claimed_by.size() > 0) {
-            // Make claimed_by uniq
-            std::sort(claimed_by.begin(), claimed_by.end());
-            std::unique(claimed_by.begin(), claimed_by.end());
+            remove_duplicates(claimed_by);
 
             // If boundary if disputed_by and territory claimed_by
             // ignore claimed_by, we are already inside the territory

--- a/src/osmborder_filter.cpp
+++ b/src/osmborder_filter.cpp
@@ -133,7 +133,9 @@ int main(int argc, char *argv[])
                 osmium::io::make_input_iterator_range<const osmium::Relation>(
                     reader);
             for (const osmium::Relation &relation : relations) {
-                if (relation.tags().has_tag("boundary", "administrative")) {
+                if (relation.tags().has_tag("boundary", "administrative") ||
+                    relation.tags().has_tag("boundary", "claim") ||
+                    relation.tags().has_tag("boundary", "disputed")) {
                     *output_it++ = relation;
                     for (const auto &rm : relation.members()) {
                         if (rm.type() == osmium::item_type::way) {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -24,6 +24,9 @@
 
 #include <memory>
 #include <type_traits>
+#include <algorithm>
+#include <functional>
+#include <string>
 
 template <typename R, typename T>
 std::unique_ptr<R> make_unique_ptr_clone(const T *source)
@@ -39,6 +42,28 @@ std::unique_ptr<TDerived> static_cast_unique_ptr(std::unique_ptr<TBase> &&ptr)
     static_assert(std::is_base_of<TBase, TDerived>::value,
                   "TDerived must be derived from TBase");
     return std::unique_ptr<TDerived>(static_cast<TDerived *>(ptr.release()));
+}
+
+// From https://stackoverflow.com/a/29185584
+std::string& ltrim(std::string& s)
+{
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(),
+    std::ptr_fun<int, int>(std::isgraph)));
+  return s;
+}
+
+// From https://stackoverflow.com/a/29185584
+std::string& rtrim(std::string& s)
+{
+  s.erase(std::find_if(s.rbegin(), s.rend(),
+    std::ptr_fun<int, int>(std::isgraph)).base(), s.end());
+  return s;
+}
+
+// From https://stackoverflow.com/a/29185584
+std::string& trim(std::string& s)
+{
+  return ltrim(rtrim(s));
 }
 
 #endif // UTIL_HPP


### PR DESCRIPTION
Try to implement #13

Add disputed_by and claimed_by to the output.

The idea is to have the alternative boundaries accepted by countries and rejected by countries.
